### PR TITLE
DaemonSet: Ensure leading `v` when defaulting to `.Chart.AppVersion`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Improve Chart.yaml metadata and management.
 - PolicyException: Use Kyverno-native API instead of Giant Swarm abstraction.
+- DaemonSet: Ensure leading `v` when defaulting to `.Chart.AppVersion`.
 
 ## [0.2.0] - 2025-02-25
 

--- a/helm/kube-vip/templates/daemonset.yaml
+++ b/helm/kube-vip/templates/daemonset.yaml
@@ -55,7 +55,7 @@ spec:
         envFrom:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-        image: {{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}
+        image: {{ .Values.image.repository }}:{{ .Values.image.tag | default (printf "v%s" (trimPrefix "v" .Chart.AppVersion)) }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         name: kube-vip
         resources:


### PR DESCRIPTION
We re-tag these images with a `v`, but `.Chart.AppVersion` might come without it, so we need to make sure the tag has at least one leading `v`.